### PR TITLE
Updating fireworks:orange so it has the correct name

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,7 @@ end
 
 
 minetest.register_craft({
-	output = "fireworks:firework_orange",
+	output = "fireworks:orange",
 	recipe = {
 		{"default:paper"},
 		{"tnt:gunpowder"},


### PR DESCRIPTION
Updating the fireworks:orange to have the correct name so it is able to be crafted.